### PR TITLE
Handle editing new files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ function displayError(error, editor, editorView) {
 function lint() {
 	var editor = atom.workspace.getActiveEditor();
 	var editorView = atom.workspaceView.getActiveView();
-	var file = editor.getUri();
 
 	if (!editor) {
 		return;
@@ -41,16 +40,15 @@ function lint() {
 		return;
 	}
 
-	if (typeof file === 'undefined') {
-		file = '';
-	}
+	var file = editor.getUri();
+	var config = file ? loadConfig(file) : {};
 
 	// reset
 	editorView.resetDisplay();
 	editorView.gutter.find('.jshint-gutter').remove();
 	atom.workspaceView.statusBar.find('#jshint-statusbar').remove();
 
-	jshint(editor.getText(), loadConfig(file));
+	jshint(editor.getText(), config);
 
 	// workaround the errors array sometimes containing `null`
 	var errors = _.compact(jshint.errors);


### PR DESCRIPTION
`editor.getUri()` returns `undefined` when editing a new file which causes a TypeError when trying to resolve the path. This change prevents the path errors; however, the default (or home) configuration will be used.

Atom doesn't currently have a way to get the editor's working directory when editing a new file (`editor.getPath()` also returns `undefined`) and `process.cwd()` returns `'/'` which doesn't resolve to allow the local .jshintrc to be found.

There's room for improvement here, but this will prevent the error that currently occurs.
