### PR TITLE
Remove linting errors and add css class to match rest of status bar

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,8 @@
 	"unused": true,
 	"strict": true,
 	"trailing": true,
-	"smarttabs": true
+	"smarttabs": true,
+	"globals": {
+		"atom": true
+	}
 }

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ var plugin = module.exports;
 Subscriber.extend(plugin);
 
 function updateStatusbar(error) {
-	atom.workspaceView.statusBar.appendLeft('<span id="jshint-statusbar">JSHint ' + error.line + ':' + error.character + ' ' + error.reason + '</span>');
+	atom.workspaceView.statusBar.appendLeft('<span id="jshint-statusbar" class="inline-block">JSHint ' + error.line + ':' + error.character + ' ' + error.reason + '</span>');
 }
 
 function displayError(error, editor, editorView) {
-	var line = error[0].line || 1; // jshint reports `line: 0` when config error
+	var line = error[0].line || 1; // JSHint reports `line: 0` when config error
 	var row = line - 1;
 	var gutter = editorView.gutter;
 	var bufferRange = editor.bufferRangeForBufferRow(row);


### PR DESCRIPTION
Removes the couple of linting errors in the files I was working with and adds a class to match the rest of the status bar text (was incorrectly aligned before).

On a side note, anyone know how to properly develop atom plugins? I can't seem to get `apm link` working as expected.
