### PR TITLE
Add JavaScript(JSX) grammar

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function lint() {
 		return;
 	}
 
-	if (editor.getGrammar().name !== 'JavaScript') {
+	if (['JavaScript', 'JavaScript (JSX)'].indexOf(editor.getGrammar().name) === -1) {
 		return;
 	}
 


### PR DESCRIPTION
Adding "JavaScript (JSX)" grammar allows to use [atom-react](https://github.com/orktes/atom-react).
