### PR TITLE
Fix error when statusBar is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function lint() {
 	// reset
 	editorView.resetDisplay();
 	editorView.gutter.find('.jshint-line-number').removeClass('jshint-line-number');
-	atom.workspaceView.statusBar.find('#jshint-statusbar').remove();
+	if(atom.workspaceView.statusBar){
+		atom.workspaceView.statusBar.find('#jshint-statusbar').remove();
+	}
 
 	var linter = (atom.config.get('jshint.supportLintingJsx') || atom.config.get('jshint.transformJsx')) ? jsxhint : jshint;
 	linter(editor.getText(), config, config.globals);


### PR DESCRIPTION
The package cannot load because `atom.workspaceView.statusBar` is not defined. 

Using the example in [atom/status-bar](https://github.com/atom/status-bar) :

``` Coffeescript
module.exports =
  activate: ->
    atom.packages.once 'activated', ->
      atom.workspaceView.statusBar?.appendLeft('<span>hi!</span>')
```

You notice the `?`, so it means this variable could be null.
