### PR TITLE
Add markers to track error lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,11 +94,11 @@ function addReasons(marker, error) {
 	var row = getRowForError(error);
 	var editorView = atom.workspaceView.getActiveView();
 	var gutter = editorView.gutter;
-	var reasons = getReasonsForError(error).join('<br />');
+	var reasons = '<div class="jshint-errors">' + getReasonsForError(error).join('<br />') + '</div>';
 
 	var gutterRow = gutter.find(gutter.getLineNumberElement(row));
 	gutterRow.destroyTooltip();
-	gutterRow.setTooltip({title: reasons, placement: 'bottom'});
+	gutterRow.setTooltip({title: reasons, placement: 'bottom', delay: {show: 200}});
 	marker.on('changed destroyed', function() {
 		gutterRow.destroyTooltip();
 	});

--- a/stylesheets/jshint.less
+++ b/stylesheets/jshint.less
@@ -4,6 +4,10 @@
 	background-color: fade(@background-color-error, 20%);
 }
 
+.jshint-errors {
+  text-align: left;
+}
+
 .editor {
 	.gutter {
 		.jshint-line-number {


### PR DESCRIPTION
Keeps track of marks to prevent re-creating the same mark multiple times and so it can properly destroy marks (and their decorations) when they are no longer valid.

Should fix https://github.com/sindresorhus/atom-jshint/issues/32

It's entirely possible that I missed some use-case here, so other eyes are appreciated.
