### PR TITLE
Allow removing an editor that has no editorView.editor

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,9 @@ function registerEvents() {
 	});
 
 	atom.workspaceView.on('editor:will-be-removed', function (e, editorView) {
-		removeMarkersForEditorId(editorView.editor.id);
+		if (editorView && editorView.editor) {
+			removeMarkersForEditorId(editorView.editor.id);
+		}
 	});
 }
 


### PR DESCRIPTION
eg: the Settings window.

Fixes https://github.com/sindresorhus/atom-jshint/issues/39
