### PR TITLE
Removes appendLeft deprecation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,20 @@ var SUPPORTED_GRAMMARS = [
 	'source.js.jsx'
 ];
 
+var jsHintStatusBar = document.createElement('span');
+jsHintStatusBar.setAttribute('id', 'jshint-statusbar');
+jsHintStatusBar.classList.add('inline-block');
+
+function updateStatusText(line, character, reason) {
+
+	if (!line && !character && !reason) {
+		jsHintStatusBar.innerText = '';
+	}
+	else {
+		jsHintStatusBar.innerText = 'JSHint ' + line + ':' + character + ' ' + reason;
+	}
+}
+
 function getMarkersForEditor() {
 	var editor = atom.workspace.getActiveTextEditor();
 
@@ -92,13 +106,13 @@ function updateStatusbar() {
 		return;
 	}
 
-	var jsHintStatusBar = statusBar.querySelector('#jshint-statusbar');
-	if (jsHintStatusBar && jsHintStatusBar.parentNode) {
-		jsHintStatusBar.parentNode.removeChild(jsHintStatusBar);
+	if (!jsHintStatusBar.parentNode) {
+		statusBar.addLeftTile({ item: jsHintStatusBar });
 	}
 
 	var editor = atom.workspace.getActiveTextEditor();
 	if (!editor || !errorsByEditorId[editor.id]) {
+		updateStatusText();
 		return;
 	}
 
@@ -106,7 +120,7 @@ function updateStatusbar() {
 	var error = errorsByEditorId[editor.id][line] || _.first(_.compact(errorsByEditorId[editor.id]));
 	error = error[0];
 
-	statusBar.appendLeft('<span id="jshint-statusbar" class="inline-block">JSHint ' + error.line + ':' + error.character + ' ' + error.reason + '</span>');
+	updateStatusText(error.line, error.character, error.reason);
 }
 
 function getRowForError(error) {


### PR DESCRIPTION
[Following https://github.com/sindresorhus/atom-jshint/pull/77#issuecomment-90842468]

I'm rather unsure about `Use TextBuffer::onDidSave` deprecation though, it looks like coming from the package `emissary` so it should be fixed in their repo instead, right?

Also, I was not certain about the way to go, I think that creating / deleting the statusbar over and over was less efficient than just updating its text when needed, maybe I'm wrong though^^