### PR TITLE
Updates status bar when cursor is moved.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use babel';
 
 /* globals atom */
-import { CompositeDisposable } from 'atom';
-import emissary from 'emissary';
+import { CompositeDisposable } from 'event-kit';
 import path from 'path';
 import reactDomPragma from 'react-dom-pragma';
 import lazyRequire from 'lazy-req';
@@ -18,8 +17,6 @@ const markersByEditorId = {};
 const errorsByEditorId = {};
 const subscriptionTooltips = new CompositeDisposable();
 let _;
-
-emissary.Subscriber.extend(plugin);
 
 const SUPPORTED_GRAMMARS = [
 	'source.js',
@@ -299,7 +296,7 @@ export const config = plugin.config = {
 export const activate = plugin.activate = () => {
 	_ = lodash();
 	registerEvents();
-	plugin.subscribe(atom.config.observe('jshint.validateOnlyOnSave', registerEvents));
+	atom.config.observe('jshint.validateOnlyOnSave', registerEvents);
 	atom.commands.add('atom-workspace', 'jshint:lint', lint);
 };
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "jsx"
   ],
   "dependencies": {
-    "emissary": "^1.0.0",
+    "event-kit": "^1.2.0",
     "jshint": "^2.4.4",
     "jshint-jsx": "^0.4.0",
     "lazy-req": "^1.0.0",
-    "lodash": "^3.6.0",
+    "lodash": "^3.10.0",
     "react-dom-pragma": "^1.0.0",
     "shelljs": "^0.5.0",
     "strip-json-comments": "^1.0.1",


### PR DESCRIPTION
It was broken but I never really payed attention to it, it seems that
`atom.workspaceView.on('cursor:moved', updateStatusbar);` didn't work
anymore.

[Fixes #17]