### PR TITLE
Remove default parameter of `findFile`

### DIFF
--- a/load-config.js
+++ b/load-config.js
@@ -18,12 +18,11 @@ const findFileResults = {};
  * or hits the root.
  *
  * @param {string} name filename to search for (e.g. .jshintrc)
- * @param {string} dir  directory to start search from (default:
- *                      current working directory)
+ * @param {string} dir  directory to start search from
  *
  * @returns {string} normalized filename
  */
-const findFile = (name, dir=process.cwd()) => {
+const findFile = (name, dir) => {
   const filename = path.normalize(path.join(dir, name));
   if (findFileResults[filename] !== undefined) {
     return findFileResults[filename];


### PR DESCRIPTION
When defining default parameter:

    const findFile = (name, dir=process.cwd())

`dir` may contain a funtion. It was the case for me.
As `findFile` is never used without `dir` parameter is assume it safe to remove.

Fixes #100