### PR TITLE
go to error (incl. by clicking on status bar)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,28 @@ const SUPPORTED_GRAMMARS = [
 	'source.js.jsx'
 ];
 
+let currentLine = null;
+let currentChar = null;
+
+const goToError = () => {
+	const editor = atom.workspace.getActiveTextEditor();
+
+	if (!editor || !currentLine || !currentChar) {
+		return;
+	}
+
+	editor.setCursorBufferPosition([currentLine - 1, currentChar - 1]);
+};
+
 const jsHintStatusBar = document.createElement('span');
 jsHintStatusBar.setAttribute('id', 'jshint-statusbar');
 jsHintStatusBar.classList.add('inline-block');
+jsHintStatusBar.addEventListener('click', goToError);
 
 const updateStatusText = (line, character, reason) => {
 	jsHintStatusBar.textContent = line && character && reason ? `JSHint ${line}:${character} ${reason}` : '';
+	currentLine = line;
+	currentChar = character;
 };
 
 const getMarkersForEditor = () => {
@@ -310,6 +326,7 @@ export const activate = plugin.activate = () => {
 	atom.config.observe('jshint.onlyConfig', registerEvents);
 	atom.config.observe('jshint.validateOnlyOnSave', registerEvents);
 	atom.commands.add('atom-workspace', 'jshint:lint', lint);
+	atom.commands.add('atom-workspace', 'jshint:go-to-error', goToError);
 };
 
 export default plugin;

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ const SUPPORTED_GRAMMARS = [
 	'source.js.jsx'
 ];
 
-let currentLine = null;
-let currentChar = null;
+let currentLine;
+let currentChar;
 
 const goToError = () => {
 	const editor = atom.workspace.getActiveTextEditor();
@@ -35,7 +35,7 @@ const goToError = () => {
 	editor.setCursorBufferPosition([currentLine - 1, currentChar - 1]);
 };
 
-const jsHintStatusBar = document.createElement('span');
+const jsHintStatusBar = document.createElement('a');
 jsHintStatusBar.setAttribute('id', 'jshint-statusbar');
 jsHintStatusBar.classList.add('inline-block');
 jsHintStatusBar.addEventListener('click', goToError);

--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,11 @@ Or Settings → Install → Search for `jshint` *(install `Jshint`, not `Atom Js
 - Validates in realtime.
 - Line and line number turns red on error.
 - Hover over the line number to see the errors.
-- Displays the error from the current line or the first error in the statusbar.
+- Displays the error from the current line or the first error in the statusbar; clicking the statusbar message moves the cursor to the error.
 - Reads your `.jshintrc` config and `jshintConfig` in package.json using the same logic as JSHint.
 - Option to only validate on save.
 - Command `Jshint: Lint` to manually lint.
+- Command `Jshint: Go To Error` to move the cursor to the error displayed in the statusbar.
 - Supports [React JSX](http://facebook.github.io/react/docs/jsx-in-depth.html). *(must be enabled in Settings)*
 
 


### PR DESCRIPTION
Hi, this PR proposes a new JSHint command, go-to-error, which will move the cursor to the error currently shown in the status bar. It's a new palette command `jshint:go-to-error` which can be bound to a key, and also it works when clicking on the status bar message.

Please let me know if there's any comments or concerns about this.