### PR TITLE
Add JSHint error code to displayed reason.

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ const goToNextError = () => {
 };
 
 const getReasonsForError = error => {
-	return _.map(error, el => `${el.character}: ${el.reason}`);
+	return _.map(error, el => `${el.character} [${el.code}]: ${el.reason}`);
 };
 
 const addReasons = (editor, marker, error) => {


### PR DESCRIPTION
The JSHint error code makes it easier to add 'silencer comments' (`/* jshint -W000 */`).

-

Fixes #115.