### PR TITLE
Add consumeStatusBar service

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ let subscriptionTooltips = new CompositeDisposable();
 let subscriptionEvents = new CompositeDisposable();
 
 let _;
+let statusBar;
 
 const SUPPORTED_GRAMMARS = [
 	'source.js',
@@ -112,8 +113,6 @@ const getMarkerAtRow = (editor, row) => {
 };
 
 const updateStatusbar = () => {
-	const statusBar = atom.views.getView(atom.workspace).querySelector('.status-bar');
-
 	if (!statusBar) {
 		return;
 	}
@@ -354,5 +353,7 @@ export const deactivate = plugin.deactivate = () => {
 	subscriptionEvents.dispose();
 	subscriptionMain.dispose();
 };
+
+export const consumeStatusBar = plugin.consumeStatusBar = instance => statusBar = instance;
 
 export default plugin;

--- a/package.json
+++ b/package.json
@@ -49,5 +49,12 @@
     "ignores": [
       "fixture*"
     ]
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^1.0.0": "consumeStatusBar"
+      }
+    }
   }
 }


### PR DESCRIPTION
Consume service from Atom's status bar element to get the status bar instance. This fixes collisions with other packages that create a status bar at the bottom. This is also the recommended way to attach to the
status bar.